### PR TITLE
Hide temporary users from suggestions

### DIFF
--- a/src/Server/Im/Database.purs
+++ b/src/Server/Im/Database.purs
@@ -85,12 +85,7 @@ suggest loggedUserId skip = case _ of
       baseFilter = u ... _id .<>. loggedUserId .&&. visibilityFilter .&&. blockedFilter
 
       visibilityFilter =
-            _visibility .=. Everyone .&&. _temporary .=. Checked false
-                  .||. (_visibility .=. NoTemporaryUsers .||. _temporary .=. Checked true)
-                  .&&. (exists $ select (1 # as u) # from users # wher (_id .=. loggedUserId .&&. _temporary .=. Checked false .&&. _visibility .=. Everyone))
-                  .||. _temporary
-                  .=. Checked true
-                  .&&. (exists $ select (1 # as u) # from users # wher (_id .=. loggedUserId .&&. _temporary .=. Checked true))
+            _visibility .=. Everyone .&&. _temporary .=. Checked false .||. _visibility .=. NoTemporaryUsers .&&. not (exists $ select (1 # as u) # from users # wher (_id .=. loggedUserId .&&. _temporary .=. Checked true))
 
       blockedFilter = not (exists $ select (1 # as u) # from blocks # wher (_blocker .=. loggedUserId .&&. _blocked .=. u ... _id .||. _blocker .=. u ... _id .&&. _blocked .=. loggedUserId))
 

--- a/src/Shared/Im/View/SuggestionProfile.purs
+++ b/src/Shared/Im/View/SuggestionProfile.purs
@@ -194,7 +194,7 @@ displayProfile index loggedUser { karmaPosition, name, availability, temporary, 
                                 , HE.div (HA.class' "explain-temporary-user duller")
                                         [ HE.p_ "Quick-sign up means users that just got started on MeroChat and have yet to finish creating their account"
                                         , HE.p_
-                                                [ HE.text "You can opt to not see (or be messaged by) quick-sign up users on the "
+                                                [ HE.text "You can opt to not be seen (or messaged by) quick-sign up users on the "
                                                 , HE.a (HA.onClick msg) " settings"
                                                 , HE.text " page"
                                                 ]

--- a/test/Server/Im/Action.purs
+++ b/test/Server/Im/Action.purs
@@ -84,18 +84,18 @@ tests = do
                   $ TS.serverAction
                   $ do
                           Tuple userId anotherUserId ← setUpUsers
-                          SD.execute $ update users # set (_temporary .=. Checked true) # wher (_id .=. anotherUserId)
-                          SSA.changePrivacySettings userId { profileVisibility: NoTemporaryUsers, onlineStatus: true, typingStatus: true, messageTimestamps: true, readReceipts: true }
-                          suggestions ← SIA.suggest anotherUserId 0 Nothing
+                          SD.execute $ update users # set (_temporary .=. Checked true) # wher (_id .=. userId)
+                          SSA.changePrivacySettings anotherUserId { profileVisibility: NoTemporaryUsers, onlineStatus: true, typingStatus: true, messageTimestamps: true, readReceipts: true }
+                          suggestions ← SIA.suggest userId 0 Nothing
                           R.liftAff $ TUA.equal [] suggestions
 
-            TU.test "suggest shows temporary users to temporary users"
+            TU.test "suggest never shows temporary users"
                   $ TS.serverAction
                   $ do
                           Tuple userId anotherUserId ← setUpUsers
-                          SD.execute $ update users # set (_temporary .=. Checked true)
+                          SD.execute $ update users # set (_temporary .=. Checked true) # wher (_id .=. anotherUserId)
                           suggestions ← SIA.suggest userId 0 Nothing
-                          R.liftAff <<< TUA.equal [anotherUserId] $ map _.id suggestions
+                          R.liftAff $ TUA.equal [] suggestions
 
             TU.test "suggest includes all users if impersonating"
                   $ TS.serverAction


### PR DESCRIPTION
Do not show quick sign up (aka temporary) users on suggestion cards. The visibility setting for "registered only users" now works only to not show regular users to temporary ones.

Closes #263 