### PR TITLE
Fixes not showing failed message status

### DIFF
--- a/src/Shared/Im/View/ChatHistory.purs
+++ b/src/Shared/Im/View/ChatHistory.purs
@@ -110,8 +110,8 @@ chatHistory { user: { id: loggedUserId, messageTimestamps, joined, temporary, re
                                                 }
                                         )
                                         [ HE.span (HA.class' { hidden: noTimestamps }) $ SD.agoWithTime (DN.unwrap date)
-                                        , HE.span (HA.class' { hidden: incomingMessage || noTimestamps || ( noReadReceipts && status /= Errored ) }) " - " 
-                                        , HE.span (HA.class' { hidden: incomingMessage || ( noReadReceipts && status /= Errored ) }) $ show status
+                                        , HE.span (HA.class' { hidden: incomingMessage || noTimestamps || noReadReceipts && status /= Errored }) " - "
+                                        , HE.span (HA.class' { hidden: incomingMessage || noReadReceipts && status /= Errored }) $ show status
                                         ]
                                 ]
                         ]

--- a/src/Shared/Im/View/ChatHistory.purs
+++ b/src/Shared/Im/View/ChatHistory.purs
@@ -110,8 +110,8 @@ chatHistory { user: { id: loggedUserId, messageTimestamps, joined, temporary, re
                                                 }
                                         )
                                         [ HE.span (HA.class' { hidden: noTimestamps }) $ SD.agoWithTime (DN.unwrap date)
-                                        , HE.span (HA.class' { hidden: incomingMessage || noTimestamps || ( noReadReceipts && status != Errored ) }) " - " 
-                                        , HE.span (HA.class' { hidden: incomingMessage || ( noReadReceipts && status != Errored ) }) $ show status
+                                        , HE.span (HA.class' { hidden: incomingMessage || noTimestamps || ( noReadReceipts && status /= Errored ) }) " - " 
+                                        , HE.span (HA.class' { hidden: incomingMessage || ( noReadReceipts && status /= Errored ) }) $ show status
                                         ]
                                 ]
                         ]

--- a/src/Shared/Im/View/ChatHistory.purs
+++ b/src/Shared/Im/View/ChatHistory.purs
@@ -110,8 +110,8 @@ chatHistory { user: { id: loggedUserId, messageTimestamps, joined, temporary, re
                                                 }
                                         )
                                         [ HE.span (HA.class' { hidden: noTimestamps }) $ SD.agoWithTime (DN.unwrap date)
-                                        , HE.span (HA.class' { hidden: incomingMessage || noTimestamps || noReadReceipts }) " - "
-                                        , HE.span (HA.class' { hidden: incomingMessage || noReadReceipts }) $ show status
+                                        , HE.span (HA.class' { hidden: incomingMessage || noTimestamps || ( noReadReceipts && status != Errored ) }) " - " 
+                                        , HE.span (HA.class' { hidden: incomingMessage || ( noReadReceipts && status != Errored ) }) $ show status
                                         ]
                                 ]
                         ]


### PR DESCRIPTION
Fixes not showing failed message status, when `Read receipts` is turned off.

Closes #268 